### PR TITLE
[Test/#170] 초대 대기자 목록 조회 service 단위 테스트 & 구현

### DIFF
--- a/worker-management-component/src/main/java/shop/wazard/adapter/out/persistence/WorkerManagementDbAdapter.java
+++ b/worker-management-component/src/main/java/shop/wazard/adapter/out/persistence/WorkerManagementDbAdapter.java
@@ -8,6 +8,7 @@ import shop.wazard.application.domain.WaitingInfo;
 import shop.wazard.application.port.out.AccountForWorkerManagementPort;
 import shop.wazard.application.port.out.RosterForWorkerManagementPort;
 import shop.wazard.application.port.out.WaitingListForWorkerManagementPort;
+import shop.wazard.dto.WaitingWorkerResDto;
 import shop.wazard.dto.WorkerBelongedToCompanyResDto;
 import shop.wazard.entity.account.AccountJpa;
 import shop.wazard.entity.company.CompanyJpa;
@@ -87,4 +88,10 @@ class WorkerManagementDbAdapter implements AccountForWorkerManagementPort, Roste
                 .orElseThrow(() -> new RosterNotFoundException(StatusEnum.ROSTER_NOT_FOUND.getMessage()));
         workerForManagementMapper.updateRosterStateForExile(rosterJpa, rosterForWorkerManagement);
     }
+
+    @Override
+    public List<WaitingWorkerResDto> getWaitingWorker(Long companyId) {
+        return null;
+    }
+
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
@@ -58,7 +58,9 @@ class WorkerManagementServiceImpl implements WorkerManagementService {
 
     @Override
     public List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto) {
-        return null;
+        AccountForWorkerManagement accountForWorkerManagement = accountForWorkerManagementPort.findAccountByEmail(waitingWorkerReqDto.getEmail());
+        accountForWorkerManagement.checkIsEmployer();
+        return rosterForWorkerManagementPort.getWaitingWorker(waitingWorkerReqDto.getCompanyId());
     }
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
@@ -56,4 +56,9 @@ class WorkerManagementServiceImpl implements WorkerManagementService {
                 .build();
     }
 
+    @Override
+    public List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto) {
+        return null;
+    }
+
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
@@ -12,4 +12,6 @@ public interface WorkerManagementService {
 
     ExileWorkerResDto exileWorker(ExileWorkerReqDto exileWorkerReqDto);
 
+    List<WaitingWorkerResDto> getWaitingWorker(WaitingWorkerReqDto waitingWorkerReqDto);
+
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
@@ -12,6 +12,6 @@ public interface WorkerManagementService {
 
     ExileWorkerResDto exileWorker(ExileWorkerReqDto exileWorkerReqDto);
 
-    List<WaitingWorkerResDto> getWaitingWorker(WaitingWorkerReqDto waitingWorkerReqDto);
+    List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto);
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/out/RosterForWorkerManagementPort.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/out/RosterForWorkerManagementPort.java
@@ -1,6 +1,7 @@
 package shop.wazard.application.port.out;
 
 import shop.wazard.application.domain.RosterForWorkerManagement;
+import shop.wazard.dto.WaitingWorkerResDto;
 import shop.wazard.dto.WorkerBelongedToCompanyResDto;
 
 import java.util.List;
@@ -14,5 +15,7 @@ public interface RosterForWorkerManagementPort {
     RosterForWorkerManagement findRoster(Long accountId, Long companyId);
 
     void exileWorker(RosterForWorkerManagement rosterForWorkerManagement);
+
+    List<WaitingWorkerResDto> getWaitingWorker(Long companyId);
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/dto/WaitingWorkerReqDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/WaitingWorkerReqDto.java
@@ -1,0 +1,22 @@
+package shop.wazard.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WaitingWorkerReqDto {
+
+    @Positive
+    private Long companyId;
+
+    @Pattern(regexp = "^(?:\\w+\\.?)*\\w+@(?:\\w+\\.)+\\w+$", message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    private String email;
+
+}

--- a/worker-management-component/src/main/java/shop/wazard/dto/WaitingWorkerResDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/WaitingWorkerResDto.java
@@ -1,0 +1,16 @@
+package shop.wazard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import shop.wazard.application.domain.WaitingStatus;
+
+@Getter
+@Builder
+public class WaitingWorkerResDto {
+
+    private Long accountId;
+    private String email;
+    private String userName;
+    private WaitingStatus waitingStatus;
+
+}

--- a/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
+++ b/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
@@ -14,12 +14,12 @@ import shop.wazard.application.port.in.WorkerManagementService;
 import shop.wazard.application.port.out.AccountForWorkerManagementPort;
 import shop.wazard.application.port.out.RosterForWorkerManagementPort;
 import shop.wazard.application.port.out.WaitingListForWorkerManagementPort;
-import shop.wazard.dto.ExileWorkerReqDto;
-import shop.wazard.dto.ExileWorkerResDto;
-import shop.wazard.dto.PermitWorkerToJoinReqDto;
-import shop.wazard.dto.WorkerBelongedToCompanyReqDto;
+import shop.wazard.dto.*;
 import shop.wazard.exception.JoinWorkerDeniedException;
 import shop.wazard.exception.NotAuthorizedException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -166,6 +166,62 @@ class WorkerManagementServiceTest {
 
         // then
         Assertions.assertEquals(workerManagementService.exileWorker(exileWorkerReqDto).getMessage(), exileWorkerResDto.getMessage());
+    }
+
+    @Test
+    @DisplayName("고용주 - 초대 대기자 목록 조회 - 성공")
+    public void getWaitingWorkersSuccess() throws Exception {
+        // given
+        WaitingWorkerReqDto waitingWorkerReqDto = WaitingWorkerReqDto.builder()
+                .companyId(10L)
+                .email("employer@email.com")
+                .build();
+        AccountForWorkerManagement accountForWorkerManagement = AccountForWorkerManagement.builder()
+                .id(1L)
+                .roles("EMPLOYER")
+                .build();
+        List<WaitingWorkerResDto> waitingWorkerResDtoList = setWaitingWorkerResDtoList();
+
+        // when
+        Mockito.when(accountForWorkerManagementPort.findAccountByEmail(anyString()))
+                .thenReturn(accountForWorkerManagement);
+        Mockito.when(rosterForWorkerManagementPort.getWaitingWorker(anyLong()))
+                .thenReturn(waitingWorkerResDtoList);
+
+        List<WaitingWorkerResDto> result = workerManagementService.getWaitingWorkers(waitingWorkerReqDto);
+
+        // then
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getAccountId(), result.get(0).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getWaitingStatus(), result.get(0).getWaitingStatus()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getAccountId(), result.get(1).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getWaitingStatus(), result.get(1).getWaitingStatus()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getAccountId(), result.get(2).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getWaitingStatus(), result.get(2).getWaitingStatus())
+        );
+    }
+
+    private List<WaitingWorkerResDto> setWaitingWorkerResDtoList() {
+        List<WaitingWorkerResDto> waitingWorkerResDtoList = new ArrayList<>();
+        waitingWorkerResDtoList.add(WaitingWorkerResDto.builder()
+                .accountId(1L)
+                .userName("testName1")
+                .waitingStatus(WaitingStatus.AGREED)
+                .email("test1@email.com")
+                .build());
+        waitingWorkerResDtoList.add(WaitingWorkerResDto.builder()
+                .accountId(2L)
+                .userName("testName2")
+                .waitingStatus(WaitingStatus.DISAGREED)
+                .email("test2@email.com")
+                .build());
+        waitingWorkerResDtoList.add(WaitingWorkerResDto.builder()
+                .accountId(4L)
+                .userName("testName4")
+                .waitingStatus(WaitingStatus.INVITED)
+                .email("test4@email.com")
+                .build());
+        return waitingWorkerResDtoList;
     }
 
 }

--- a/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
+++ b/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
@@ -193,10 +193,18 @@ class WorkerManagementServiceTest {
         // then
         Assertions.assertAll(
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getAccountId(), result.get(0).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getUserName(), result.get(0).getUserName()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getEmail(), result.get(0).getEmail()),
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(0).getWaitingStatus(), result.get(0).getWaitingStatus()),
+
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getAccountId(), result.get(1).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getUserName(), result.get(1).getUserName()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getEmail(), result.get(1).getEmail()),
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(1).getWaitingStatus(), result.get(1).getWaitingStatus()),
+
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getAccountId(), result.get(2).getAccountId()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getUserName(), result.get(2).getUserName()),
+                () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getEmail(), result.get(2).getEmail()),
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getWaitingStatus(), result.get(2).getWaitingStatus())
         );
     }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #170 

### 핵심 내용
<!-- 무엇을 했는가 -->
- service 구현
- service 단위 테스트

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
- 없음

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
- 대기자 목록 화면 디자인이 없어서 ResDto 클래스는 아래와 같이 구성
```java
@Getter
@Builder
public class WaitingWorkerResDto {

    private Long accountId;
    private String email;
    private String userName;
    private WaitingStatus waitingStatus;

}
```
- 대기자 목록을 조회할 때, `가입이 이미 승인된 근무자들은 조회되지 않는다` 고 가정하였음
  - 이 부분에 대한 의견 남겨줘 