### PR TITLE
[Test/#182] 특정 근무자 상세조회 service 단위 테스트 & 구현

### DIFF
--- a/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
@@ -13,7 +13,6 @@ import shop.wazard.application.port.out.RosterForWorkerManagementPort;
 import shop.wazard.application.port.out.WaitingListForWorkerManagementPort;
 import shop.wazard.dto.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Transactional
@@ -69,10 +68,10 @@ class WorkerManagementServiceImpl implements WorkerManagementService {
 
     @Transactional(readOnly = true)
     @Override
-    public GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date) {
+    public GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, int year, int month) {
         AccountForWorkerManagement accountForWorkerManagement = accountForWorkerManagementPort.findAccountByEmail(getWorkerAttendacneRecordReqDto.getEmail());
         accountForWorkerManagement.checkIsEmployer();
-        return commuteRecordForWorkerManagementPort.getWorkerAttendanceRecord(getWorkerAttendacneRecordReqDto, date);
+        return commuteRecordForWorkerManagementPort.getWorkerAttendanceRecord(getWorkerAttendacneRecordReqDto, year, month);
     }
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/WorkerManagementServiceImpl.java
@@ -8,10 +8,12 @@ import shop.wazard.application.domain.RosterForWorkerManagement;
 import shop.wazard.application.domain.WaitingInfo;
 import shop.wazard.application.port.in.WorkerManagementService;
 import shop.wazard.application.port.out.AccountForWorkerManagementPort;
+import shop.wazard.application.port.out.CommuteRecordForWorkerManagementPort;
 import shop.wazard.application.port.out.RosterForWorkerManagementPort;
 import shop.wazard.application.port.out.WaitingListForWorkerManagementPort;
 import shop.wazard.dto.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Transactional
@@ -22,6 +24,7 @@ class WorkerManagementServiceImpl implements WorkerManagementService {
     private final AccountForWorkerManagementPort accountForWorkerManagementPort;
     private final RosterForWorkerManagementPort rosterForWorkerManagementPort;
     private final WaitingListForWorkerManagementPort waitingListForWorkerManagementPort;
+    private final CommuteRecordForWorkerManagementPort commuteRecordForWorkerManagementPort;
 
     @Override
     public PermitWorkerToJoinResDto permitWorkerToJoin(PermitWorkerToJoinReqDto permitWorkerToJoinReqDto) {
@@ -56,11 +59,20 @@ class WorkerManagementServiceImpl implements WorkerManagementService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto) {
         AccountForWorkerManagement accountForWorkerManagement = accountForWorkerManagementPort.findAccountByEmail(waitingWorkerReqDto.getEmail());
         accountForWorkerManagement.checkIsEmployer();
         return waitingListForWorkerManagementPort.getWaitingWorker(waitingWorkerReqDto.getCompanyId());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date) {
+        AccountForWorkerManagement accountForWorkerManagement = accountForWorkerManagementPort.findAccountByEmail(getWorkerAttendacneRecordReqDto.getEmail());
+        accountForWorkerManagement.checkIsEmployer();
+        return commuteRecordForWorkerManagementPort.getWorkerAttendanceRecord(getWorkerAttendacneRecordReqDto, date);
     }
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
@@ -2,6 +2,7 @@ package shop.wazard.application.port.in;
 
 import shop.wazard.dto.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface WorkerManagementService {
@@ -14,6 +15,6 @@ public interface WorkerManagementService {
 
     List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto);
 
-    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto);
+    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date);
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
@@ -2,7 +2,6 @@ package shop.wazard.application.port.in;
 
 import shop.wazard.dto.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface WorkerManagementService {
@@ -15,6 +14,6 @@ public interface WorkerManagementService {
 
     List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto);
 
-    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date);
+    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, int year, int month);
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/in/WorkerManagementService.java
@@ -14,4 +14,6 @@ public interface WorkerManagementService {
 
     List<WaitingWorkerResDto> getWaitingWorkers(WaitingWorkerReqDto waitingWorkerReqDto);
 
+    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto);
+
 }

--- a/worker-management-component/src/main/java/shop/wazard/application/port/out/CommuteRecordForWorkerManagementPort.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/out/CommuteRecordForWorkerManagementPort.java
@@ -1,0 +1,12 @@
+package shop.wazard.application.port.out;
+
+import shop.wazard.dto.GetWorkerAttendacneRecordReqDto;
+import shop.wazard.dto.GetWorkerAttendanceRecordResDto;
+
+import java.time.LocalDate;
+
+public interface CommuteRecordForWorkerManagementPort {
+
+    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date);
+
+}

--- a/worker-management-component/src/main/java/shop/wazard/application/port/out/CommuteRecordForWorkerManagementPort.java
+++ b/worker-management-component/src/main/java/shop/wazard/application/port/out/CommuteRecordForWorkerManagementPort.java
@@ -3,10 +3,8 @@ package shop.wazard.application.port.out;
 import shop.wazard.dto.GetWorkerAttendacneRecordReqDto;
 import shop.wazard.dto.GetWorkerAttendanceRecordResDto;
 
-import java.time.LocalDate;
-
 public interface CommuteRecordForWorkerManagementPort {
 
-    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, LocalDate date);
+    GetWorkerAttendanceRecordResDto getWorkerAttendanceRecord(GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto, int year, int month);
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/dto/AbsentRecordDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/AbsentRecordDto.java
@@ -1,0 +1,14 @@
+package shop.wazard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class AbsentRecordDto {
+
+    private LocalDate absentDate;
+
+}

--- a/worker-management-component/src/main/java/shop/wazard/dto/CommuteRecordDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/CommuteRecordDto.java
@@ -1,0 +1,18 @@
+package shop.wazard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommuteRecordDto {
+
+    private LocalDate commuteDate;
+    private LocalDateTime enterTime;
+    private LocalDateTime exitTime;
+    private boolean tardy;
+
+}

--- a/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendacneRecordReqDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendacneRecordReqDto.java
@@ -1,0 +1,22 @@
+package shop.wazard.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetWorkerAttendacneRecordReqDto {
+
+    @Pattern(regexp = "^(?:\\w+\\.?)*\\w+@(?:\\w+\\.)+\\w+$", message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    private String email;
+
+    @Positive
+    private Long accountId;
+
+}

--- a/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendacneRecordReqDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendacneRecordReqDto.java
@@ -14,9 +14,9 @@ public class GetWorkerAttendacneRecordReqDto {
 
     @Pattern(regexp = "^(?:\\w+\\.?)*\\w+@(?:\\w+\\.)+\\w+$", message = "이메일 형식이 올바르지 않습니다.")
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
-    private String email;
+    private String email;  // 고용주의 이메일
 
     @Positive
-    private Long accountId;
+    private Long accountId;  // 조회하는 근무자의 accountId
 
 }

--- a/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendanceRecordResDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendanceRecordResDto.java
@@ -3,7 +3,6 @@ package shop.wazard.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -11,7 +10,6 @@ import java.util.List;
 public class GetWorkerAttendanceRecordResDto {
 
     private String userName;
-    private LocalDate date;
     private List<CommuteRecordDto> commuteRecordResDtoList;
     private List<AbsentRecordDto> absentRecordResDtoList;
 

--- a/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendanceRecordResDto.java
+++ b/worker-management-component/src/main/java/shop/wazard/dto/GetWorkerAttendanceRecordResDto.java
@@ -1,0 +1,18 @@
+package shop.wazard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetWorkerAttendanceRecordResDto {
+
+    private String userName;
+    private LocalDate date;
+    private List<CommuteRecordDto> commuteRecordResDtoList;
+    private List<AbsentRecordDto> absentRecordResDtoList;
+
+}

--- a/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
+++ b/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
@@ -12,12 +12,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import shop.wazard.application.domain.*;
 import shop.wazard.application.port.in.WorkerManagementService;
 import shop.wazard.application.port.out.AccountForWorkerManagementPort;
+import shop.wazard.application.port.out.CommuteRecordForWorkerManagementPort;
 import shop.wazard.application.port.out.RosterForWorkerManagementPort;
 import shop.wazard.application.port.out.WaitingListForWorkerManagementPort;
 import shop.wazard.dto.*;
 import shop.wazard.exception.JoinWorkerDeniedException;
 import shop.wazard.exception.NotAuthorizedException;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +39,8 @@ class WorkerManagementServiceTest {
     private RosterForWorkerManagementPort rosterForWorkerManagementPort;
     @MockBean
     private WaitingListForWorkerManagementPort waitingListForWorkerManagementPort;
+    @MockBean
+    private CommuteRecordForWorkerManagementPort commuteRecordForWorkerManagementPort;
 
     @Test
     @DisplayName("고용주 - 근무자 가입 수락 - 성공")
@@ -207,6 +212,100 @@ class WorkerManagementServiceTest {
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getEmail(), result.get(2).getEmail()),
                 () -> Assertions.assertEquals(waitingWorkerResDtoList.get(2).getWaitingStatus(), result.get(2).getWaitingStatus())
         );
+    }
+
+    @Test
+    @DisplayName("고용주 - 특정 근무자 상세조회 - 성공")
+    public void getWorkerAttendanceRecordSuccess() throws Exception {
+        // given
+        GetWorkerAttendacneRecordReqDto getWorkerAttendacneRecordReqDto = GetWorkerAttendacneRecordReqDto.builder()
+                .email("employer@email.com")
+                .accountId(1L)
+                .build();
+
+        AccountForWorkerManagement accountForWorkerManagement = AccountForWorkerManagement.builder()
+                .id(1L)
+                .roles("EMPLOYER")
+                .build();
+
+        List<CommuteRecordDto> commuteRecordDtoList = setDefaultCommuteRecordDtoList();
+        List<AbsentRecordDto> absentRecordDtoList = setDefaultAbsentRecordDtoList();
+
+        GetWorkerAttendanceRecordResDto getWorkerAttendanceRecordResDto = GetWorkerAttendanceRecordResDto.builder()
+                .userName("홍길동")
+                .commuteRecordResDtoList(commuteRecordDtoList)
+                .absentRecordResDtoList(absentRecordDtoList)
+                .build();
+
+        // when
+        Mockito.when(accountForWorkerManagementPort.findAccountByEmail(anyString()))
+                .thenReturn(accountForWorkerManagement);
+        Mockito.when(commuteRecordForWorkerManagementPort.getWorkerAttendanceRecord(getWorkerAttendacneRecordReqDto, 2023, 1))
+                .thenReturn(getWorkerAttendanceRecordResDto);
+
+        GetWorkerAttendanceRecordResDto result = workerManagementService.getWorkerAttendanceRecord(getWorkerAttendacneRecordReqDto, 2023, 1);
+
+        // then
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getUserName(), result.getUserName()),
+
+                () -> Assertions.assertEquals(3, result.getCommuteRecordResDtoList().size()),
+                () -> Assertions.assertEquals(2, result.getAbsentRecordResDtoList().size()),
+
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getCommuteDate(), result.getCommuteRecordResDtoList().get(0).getCommuteDate()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getEnterTime(), result.getCommuteRecordResDtoList().get(0).getEnterTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getExitTime(), result.getCommuteRecordResDtoList().get(0).getExitTime()),
+
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getCommuteDate(), result.getCommuteRecordResDtoList().get(1).getCommuteDate()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getEnterTime(), result.getCommuteRecordResDtoList().get(1).getEnterTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getExitTime(), result.getCommuteRecordResDtoList().get(1).getExitTime()),
+
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getCommuteDate(), result.getCommuteRecordResDtoList().get(2).getCommuteDate()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getEnterTime(), result.getCommuteRecordResDtoList().get(2).getEnterTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getExitTime(), result.getCommuteRecordResDtoList().get(2).getExitTime()),
+
+                () -> Assertions.assertEquals(absentRecordDtoList.get(0).getAbsentDate(), result.getAbsentRecordResDtoList().get(0).getAbsentDate()),
+                () -> Assertions.assertEquals(absentRecordDtoList.get(1).getAbsentDate(), result.getAbsentRecordResDtoList().get(1).getAbsentDate())
+        );
+    }
+
+    private List<CommuteRecordDto> setDefaultCommuteRecordDtoList() {
+        List<CommuteRecordDto> commuteRecordDtoList = new ArrayList<>();
+
+        CommuteRecordDto commuteRecordDto1 = CommuteRecordDto.builder()
+                .commuteDate(LocalDate.of(2023, 1, 2))
+                .enterTime(LocalDateTime.of(2023, 1, 1, 10, 20))
+                .build();
+        CommuteRecordDto commuteRecordDto2 = CommuteRecordDto.builder()
+                .commuteDate(LocalDate.of(2023, 1, 5))
+                .enterTime(LocalDateTime.of(2023, 1, 5, 17, 50))
+                .build();
+        CommuteRecordDto commuteRecordDto3 = CommuteRecordDto.builder()
+                .commuteDate(LocalDate.of(2023, 1, 14))
+                .enterTime(LocalDateTime.of(2023, 1, 14, 20, 20))
+                .build();
+
+        commuteRecordDtoList.add(commuteRecordDto1);
+        commuteRecordDtoList.add(commuteRecordDto2);
+        commuteRecordDtoList.add(commuteRecordDto3);
+
+        return commuteRecordDtoList;
+    }
+
+    private List<AbsentRecordDto> setDefaultAbsentRecordDtoList() {
+        List<AbsentRecordDto> absentRecordDtoList = new ArrayList<>();
+
+        AbsentRecordDto absentRecordDto1 = AbsentRecordDto.builder()
+                .absentDate(LocalDate.of(2023, 1, 1))
+                .build();
+        AbsentRecordDto absentRecordDto2 = AbsentRecordDto.builder()
+                .absentDate(LocalDate.of(2023, 1, 10))
+                .build();
+
+        absentRecordDtoList.add(absentRecordDto1);
+        absentRecordDtoList.add(absentRecordDto2);
+
+        return absentRecordDtoList;
     }
 
     private List<WaitingWorkerResDto> setWaitingWorkerResDtoList() {

--- a/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
+++ b/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
@@ -255,18 +255,22 @@ class WorkerManagementServiceTest {
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getCommuteDate(), result.getCommuteRecordResDtoList().get(0).getCommuteDate()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getEnterTime(), result.getCommuteRecordResDtoList().get(0).getEnterTime()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).getExitTime(), result.getCommuteRecordResDtoList().get(0).getExitTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(0).isTardy(), result.getCommuteRecordResDtoList().get(0).isTardy()),
 
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getCommuteDate(), result.getCommuteRecordResDtoList().get(1).getCommuteDate()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getEnterTime(), result.getCommuteRecordResDtoList().get(1).getEnterTime()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).getExitTime(), result.getCommuteRecordResDtoList().get(1).getExitTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(1).isTardy(), result.getCommuteRecordResDtoList().get(1).isTardy()),
 
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getCommuteDate(), result.getCommuteRecordResDtoList().get(2).getCommuteDate()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getEnterTime(), result.getCommuteRecordResDtoList().get(2).getEnterTime()),
                 () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).getExitTime(), result.getCommuteRecordResDtoList().get(2).getExitTime()),
+                () -> Assertions.assertEquals(getWorkerAttendanceRecordResDto.getCommuteRecordResDtoList().get(2).isTardy(), result.getCommuteRecordResDtoList().get(2).isTardy()),
 
                 () -> Assertions.assertEquals(absentRecordDtoList.get(0).getAbsentDate(), result.getAbsentRecordResDtoList().get(0).getAbsentDate()),
                 () -> Assertions.assertEquals(absentRecordDtoList.get(1).getAbsentDate(), result.getAbsentRecordResDtoList().get(1).getAbsentDate())
         );
+
     }
 
     private List<CommuteRecordDto> setDefaultCommuteRecordDtoList() {
@@ -275,14 +279,20 @@ class WorkerManagementServiceTest {
         CommuteRecordDto commuteRecordDto1 = CommuteRecordDto.builder()
                 .commuteDate(LocalDate.of(2023, 1, 2))
                 .enterTime(LocalDateTime.of(2023, 1, 1, 10, 20))
+                .exitTime(LocalDateTime.of(2023, 1, 1, 13, 0))
+                .tardy(true)
                 .build();
         CommuteRecordDto commuteRecordDto2 = CommuteRecordDto.builder()
                 .commuteDate(LocalDate.of(2023, 1, 5))
                 .enterTime(LocalDateTime.of(2023, 1, 5, 17, 50))
+                .exitTime(LocalDateTime.of(2023, 1, 5, 19, 30))
+                .tardy(false)
                 .build();
         CommuteRecordDto commuteRecordDto3 = CommuteRecordDto.builder()
                 .commuteDate(LocalDate.of(2023, 1, 14))
                 .enterTime(LocalDateTime.of(2023, 1, 14, 20, 20))
+                .exitTime(LocalDateTime.of(2023, 1, 14, 21, 0))
+                .tardy(false)
                 .build();
 
         commuteRecordDtoList.add(commuteRecordDto1);

--- a/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
+++ b/worker-management-component/src/test/java/shop/wazard/application/WorkerManagementServiceTest.java
@@ -270,7 +270,6 @@ class WorkerManagementServiceTest {
                 () -> Assertions.assertEquals(absentRecordDtoList.get(0).getAbsentDate(), result.getAbsentRecordResDtoList().get(0).getAbsentDate()),
                 () -> Assertions.assertEquals(absentRecordDtoList.get(1).getAbsentDate(), result.getAbsentRecordResDtoList().get(1).getAbsentDate())
         );
-
     }
 
     private List<CommuteRecordDto> setDefaultCommuteRecordDtoList() {


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #182 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 특정 근무자 상세조회 service 단위 테스트
- 특정 근무자 상세조회 service 구현

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
<img width="718" alt="image" src="https://github.com/TeamWazard/wazard-server/assets/48800281/a93ef419-595a-476b-b51b-8534d8527507">

- `YYYY-MM` 에 특정 근무자의 출근기록부, 결근 기록부를 조회해야 함
- 요일, 조회 날짜 `YYYY-MM`는 프런트에서 처리하기로 하여 response에 포함되지 않음
- 결석 여부는 표시되지 않는 것으로 디자인 수정되었음

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
- `YYYY-MM`을 LocalDate type으로 받지 못함 -> day가 있어야 가능함
  - 따라서 매개변수로 year, month를 넘기도록 작성한 상태
  - 대안으로 `YearMonth` 라는 자료형을 사용할 수 있는데 쿼리 작성할 때 어떨지 몰라 사용을 하지 않은 상태 