### PR TITLE
[Feat/#266] 계약정보 동의/비동의 service 단위 테스트 및 코드 구현

### DIFF
--- a/worker-component/src/main/java/shop/wazard/adapter/out/persistence/WorkerDbAdapter.java
+++ b/worker-component/src/main/java/shop/wazard/adapter/out/persistence/WorkerDbAdapter.java
@@ -4,8 +4,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import shop.wazard.application.domain.AccountForWorker;
+import shop.wazard.application.domain.ContractInfo;
 import shop.wazard.application.domain.ReplaceInfo;
 import shop.wazard.application.port.out.AccountForWorkerPort;
+import shop.wazard.application.port.out.ContractForWorkerPort;
 import shop.wazard.application.port.out.WorkerPort;
 import shop.wazard.dto.GetMyReplaceRecordReqDto;
 import shop.wazard.dto.GetMyReplaceRecordResDto;
@@ -18,7 +20,7 @@ import shop.wazard.util.exception.StatusEnum;
 
 @Repository
 @RequiredArgsConstructor
-class WorkerDbAdapter implements WorkerPort, AccountForWorkerPort {
+class WorkerDbAdapter implements WorkerPort, AccountForWorkerPort, ContractForWorkerPort {
 
     private final WorkerMapper workerMapper;
     private final AccountForWorkerMapper accountForWorkerMapper;
@@ -73,4 +75,12 @@ class WorkerDbAdapter implements WorkerPort, AccountForWorkerPort {
                 replaceJpaForWorkerRepository.findMyReplaceRecord(companyId, accountJpa.getId());
         return workerMapper.toMyReplaceRecord(replaceWorkerJpaList);
     }
+
+    @Override
+    public ContractInfo findContractInfoByContractId(Long contractId) {
+        return null;
+    }
+
+    @Override
+    public void checkContractAgreement(ContractInfo contractInfo) {}
 }

--- a/worker-component/src/main/java/shop/wazard/application/WorkerServiceImpl.java
+++ b/worker-component/src/main/java/shop/wazard/application/WorkerServiceImpl.java
@@ -5,14 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.wazard.application.domain.AccountForWorker;
+import shop.wazard.application.domain.ContractInfo;
 import shop.wazard.application.domain.ReplaceInfo;
 import shop.wazard.application.port.in.WorkerService;
 import shop.wazard.application.port.out.AccountForWorkerPort;
+import shop.wazard.application.port.out.ContractForWorkerPort;
 import shop.wazard.application.port.out.WorkerPort;
-import shop.wazard.dto.GetMyReplaceRecordReqDto;
-import shop.wazard.dto.GetMyReplaceRecordResDto;
-import shop.wazard.dto.RegisterReplaceReqDto;
-import shop.wazard.dto.RegisterReplaceResDto;
+import shop.wazard.dto.*;
 
 @Service
 @Transactional
@@ -21,6 +20,7 @@ class WorkerServiceImpl implements WorkerService {
 
     private final WorkerPort workerPort;
     private final AccountForWorkerPort accountForWorkerPort;
+    private final ContractForWorkerPort contractForWorkerPort;
 
     @Override
     public RegisterReplaceResDto registerReplace(RegisterReplaceReqDto registerReplaceReqDto) {
@@ -40,5 +40,17 @@ class WorkerServiceImpl implements WorkerService {
                 accountForWorkerPort.findAccountByEmail(getMyReplaceRecordReqDto.getEmail());
         accountForWorker.checkIsEmployee();
         return workerPort.getMyReplaceRecord(getMyReplaceRecordReqDto, companyId);
+    }
+
+    @Override
+    public CheckAgreementResDto checkAgreement(CheckAgreementReqDto checkAgreementReqDto) {
+        ContractInfo contractInfo =
+                contractForWorkerPort.findContractInfoByContractId(
+                        checkAgreementReqDto.getContractId());
+        contractInfo.changeContractAgreementState(checkAgreementReqDto);
+        contractForWorkerPort.checkContractAgreement(contractInfo);
+        return CheckAgreementResDto.builder()
+                .message(checkAgreementReqDto.isAgreementCheck() ? "동의하였습니다." : "비동의하였습니다.")
+                .build();
     }
 }

--- a/worker-component/src/main/java/shop/wazard/application/domain/ContractInfo.java
+++ b/worker-component/src/main/java/shop/wazard/application/domain/ContractInfo.java
@@ -1,0 +1,17 @@
+package shop.wazard.application.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import shop.wazard.dto.CheckAgreementReqDto;
+
+@Getter
+@Builder
+public class ContractInfo {
+
+    private Long contractId;
+    private boolean contractInfoAgreement;
+
+    public void changeContractAgreementState(CheckAgreementReqDto checkAgreementReqDto) {
+        this.contractInfoAgreement = checkAgreementReqDto.isAgreementCheck();
+    }
+}

--- a/worker-component/src/main/java/shop/wazard/application/port/in/WorkerService.java
+++ b/worker-component/src/main/java/shop/wazard/application/port/in/WorkerService.java
@@ -1,10 +1,7 @@
 package shop.wazard.application.port.in;
 
 import java.util.List;
-import shop.wazard.dto.GetMyReplaceRecordReqDto;
-import shop.wazard.dto.GetMyReplaceRecordResDto;
-import shop.wazard.dto.RegisterReplaceReqDto;
-import shop.wazard.dto.RegisterReplaceResDto;
+import shop.wazard.dto.*;
 
 public interface WorkerService {
 
@@ -12,4 +9,6 @@ public interface WorkerService {
 
     List<GetMyReplaceRecordResDto> getMyReplaceRecord(
             GetMyReplaceRecordReqDto getMyReplaceRecordReqDto, Long companyId);
+
+    CheckAgreementResDto checkAgreement(CheckAgreementReqDto checkAgreementReqDto);
 }

--- a/worker-component/src/main/java/shop/wazard/application/port/out/ContractForWorkerPort.java
+++ b/worker-component/src/main/java/shop/wazard/application/port/out/ContractForWorkerPort.java
@@ -1,8 +1,8 @@
 package shop.wazard.application.port.out;
 
+import shop.wazard.application.domain.ContractInfo;
 import shop.wazard.dto.GetEarlyContractInfoReqDto;
 import shop.wazard.dto.GetEarlyContractInfoResDto;
-import shop.wazard.application.domain.ContractInfo;
 
 public interface ContractForWorkerPort {
 

--- a/worker-component/src/main/java/shop/wazard/application/port/out/ContractForWorkerPort.java
+++ b/worker-component/src/main/java/shop/wazard/application/port/out/ContractForWorkerPort.java
@@ -1,0 +1,10 @@
+package shop.wazard.application.port.out;
+
+import shop.wazard.application.domain.ContractInfo;
+
+public interface ContractForWorkerPort {
+
+    ContractInfo findContractInfoByContractId(Long contractId);
+
+    void checkContractAgreement(ContractInfo contractInfo);
+}

--- a/worker-component/src/main/java/shop/wazard/dto/CheckAgreementReqDto.java
+++ b/worker-component/src/main/java/shop/wazard/dto/CheckAgreementReqDto.java
@@ -1,0 +1,15 @@
+package shop.wazard.dto;
+
+import javax.validation.constraints.Positive;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CheckAgreementReqDto {
+
+    @Positive private Long contractId;
+
+    private boolean agreementCheck;
+}

--- a/worker-component/src/main/java/shop/wazard/dto/CheckAgreementResDto.java
+++ b/worker-component/src/main/java/shop/wazard/dto/CheckAgreementResDto.java
@@ -1,0 +1,12 @@
+package shop.wazard.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CheckAgreementResDto {
+
+    private String message;
+}

--- a/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
+++ b/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
@@ -1,5 +1,11 @@
 package shop.wazard.application;
 
+import static org.mockito.ArgumentMatchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +22,6 @@ import shop.wazard.application.port.out.AccountForWorkerPort;
 import shop.wazard.application.port.out.ContractForWorkerPort;
 import shop.wazard.application.port.out.WorkerPort;
 import shop.wazard.dto.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {WorkerServiceImpl.class})
@@ -45,7 +44,6 @@ class WorkerServiceImplTest {
         // when
         Mockito.when(contractForWorkerPort.findContractInfoByContractId(anyLong()))
                 .thenReturn(contractInfo);
-        contractInfo.changeContractAgreementState(checkAgreementReqDto);
         CheckAgreementResDto result = workerService.checkAgreement(checkAgreementReqDto);
 
         // then
@@ -54,10 +52,7 @@ class WorkerServiceImplTest {
                         Assertions.assertEquals(
                                 checkAgreementReqDto.isAgreementCheck(),
                                 contractInfo.isContractInfoAgreement()),
-                () ->
-                        Assertions.assertEquals(
-                                "동의하였습니다.",
-                                result.getMessage()));
+                () -> Assertions.assertEquals("동의하였습니다.", result.getMessage()));
     }
 
     @Test

--- a/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
+++ b/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
@@ -16,9 +16,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import shop.wazard.application.domain.AccountForWorker;
+import shop.wazard.application.domain.ContractInfo;
 import shop.wazard.application.port.in.WorkerService;
 import shop.wazard.application.port.out.AccountForWorkerPort;
+import shop.wazard.application.port.out.ContractForWorkerPort;
 import shop.wazard.application.port.out.WorkerPort;
+import shop.wazard.dto.CheckAgreementReqDto;
 import shop.wazard.dto.GetMyReplaceRecordReqDto;
 import shop.wazard.dto.GetMyReplaceRecordResDto;
 import shop.wazard.dto.RegisterReplaceReqDto;
@@ -30,6 +33,33 @@ class WorkerServiceImplTest {
     @Autowired private WorkerService workerService;
     @MockBean private WorkerPort workerPort;
     @MockBean private AccountForWorkerPort accountForWorkerPort;
+    @MockBean private ContractForWorkerPort contractForWorkerPort;
+
+    @Test
+    @DisplayName("근무자 - 계약정보 동의/비동의 체크 - 성공")
+    void checkAgreementSuccess() throws Exception {
+        // given
+        CheckAgreementReqDto checkAgreementReqDto =
+                CheckAgreementReqDto.builder().contractId(1L).agreementCheck(true).build();
+        ContractInfo contractInfo =
+                ContractInfo.builder().contractId(1L).contractInfoAgreement(false).build();
+
+        // when
+        Mockito.when(contractForWorkerPort.findContractInfoByContractId(anyLong()))
+                .thenReturn(contractInfo);
+        contractInfo.changeContractAgreementState(checkAgreementReqDto);
+
+        // then
+        Assertions.assertAll(
+                () ->
+                        Assertions.assertEquals(
+                                checkAgreementReqDto.isAgreementCheck(),
+                                contractInfo.isContractInfoAgreement()),
+                () ->
+                        Assertions.assertEquals(
+                                "동의하였습니다.",
+                                workerService.checkAgreement(checkAgreementReqDto).getMessage()));
+    }
 
     @Test
     @DisplayName("근무자 - 대타 등록 - 성공")

--- a/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
+++ b/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
@@ -31,7 +31,6 @@ class WorkerServiceImplTest {
     @MockBean private WorkerPort workerPort;
     @MockBean private AccountForWorkerPort accountForWorkerPort;
     @MockBean private ContractForWorkerPort contractForWorkerPort;
-    @MockBean private ContractForWorkerPort contractForWorkerPort;
 
     @Test
     @DisplayName("근무자 - 계약정보 동의/비동의 체크 - 성공")

--- a/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
+++ b/worker-component/src/test/java/shop/wazard/application/WorkerServiceImplTest.java
@@ -1,11 +1,5 @@
 package shop.wazard.application;
 
-import static org.mockito.ArgumentMatchers.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +16,13 @@ import shop.wazard.application.port.out.AccountForWorkerPort;
 import shop.wazard.application.port.out.ContractForWorkerPort;
 import shop.wazard.application.port.out.WorkerPort;
 import shop.wazard.dto.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {WorkerServiceImpl.class})
@@ -45,6 +46,7 @@ class WorkerServiceImplTest {
         Mockito.when(contractForWorkerPort.findContractInfoByContractId(anyLong()))
                 .thenReturn(contractInfo);
         contractInfo.changeContractAgreementState(checkAgreementReqDto);
+        CheckAgreementResDto result = workerService.checkAgreement(checkAgreementReqDto);
 
         // then
         Assertions.assertAll(
@@ -55,7 +57,7 @@ class WorkerServiceImplTest {
                 () ->
                         Assertions.assertEquals(
                                 "동의하였습니다.",
-                                workerService.checkAgreement(checkAgreementReqDto).getMessage()));
+                                result.getMessage()));
     }
 
     @Test


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!--
[점검사항]
1. 제목 양식
2. Development 이슈 링크 걸기
3. Labels 태그 설정하기
4. 방금 작성한 코드가 최선일까 고민해보기
-->
### Issue Link
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- #266 

### 핵심 내용
<!-- 무엇을 했는가 -->
- 계약정보 동의/비동의 service 단위 테스트 및 코드 구현

### 핵심 구현 방법
<!-- 어떻게 했는가 -->
- Contract 정보를 contractId를 통해 조회 (만약 조회시 없는 계약 정보면 에러코드 반환)
- 조회된 계약정보에서 request의 동의/비동의 여부를 ContractInfo도메인 내 changeContractAgreementState메서드를 통해 변경 및 삽입
- 이후 계약정보 도메인을 repository로 파라미터로 전송

### 전달 사항
<!-- Code Review시 얘기를 나누고 싶은 내용 -->
-